### PR TITLE
Remove dual ABI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 CXX=g++
-CXXFLAGS=-std=c++11 -Wall -Wextra -pedantic -fPIC -D_GLIBCXX_USE_CXX11_ABI=0
+CXXFLAGS=-std=c++11 -Wall -Wextra -pedantic -fPIC
 LDFLAGS=-shared
 
 ifdef DEBUG


### PR DESCRIPTION
Use default GLIBCXX_USE_CXX11_ABI value (1). Build does not work with dual ABI anymore.